### PR TITLE
Refactor: Separate login logic into LoginController

### DIFF
--- a/src/main/java/com/fls/animecommunity/animesanctuary/config/SecurityConfig.java
+++ b/src/main/java/com/fls/animecommunity/animesanctuary/config/SecurityConfig.java
@@ -9,6 +9,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
@@ -16,36 +17,34 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig {
 
     @Bean
-public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-    http
-        .cors(cors -> cors.configurationSource(corsConfigurationSource())) // CORS 설정
-        .csrf(csrf -> csrf.disable()) // CSRF 비활성화
-        .authorizeHttpRequests(authorizeRequests ->
-            authorizeRequests
-                .requestMatchers("/", "/login**", "/error**").permitAll() // 공용 경로 허용
-                .requestMatchers("/api/members/register").permitAll() // 회원가입 경로도 허용
-                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll() // OPTIONS 메소드 허용
-                .anyRequest().authenticated() // 나머지는 인증 필요
-        );
-    return http.build();
-}
-
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .cors(cors -> cors.configurationSource(corsConfigurationSource())) // CORS 설정 글로벌 적용
+            .csrf(csrf -> csrf.disable()) // CSRF 비활성화 (개발 단계에서만 사용, 실제 서비스에서는 CSRF 보호를 고려)
+            .authorizeHttpRequests(authorizeRequests -> 
+                authorizeRequests
+                    .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll() // OPTIONS 메서드는 모두 허용
+                    .requestMatchers("/", "/login**", "/error**", "/api/members/**").permitAll() // 로그인, 회원가입 등 공용 경로 허용
+                    .anyRequest().authenticated() // 나머지는 인증 필요
+            );
+        return http.build();
+    }
 
     @Bean
-    public UrlBasedCorsConfigurationSource corsConfigurationSource() {
+    public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.addAllowedOrigin("http://127.0.0.1:5501"); // 프론트엔드 주소 허용
-        configuration.addAllowedMethod("*"); // 모든 메소드 허용
+        configuration.addAllowedOriginPattern("*"); // 모든 도메인 허용 (production 환경에서는 특정 도메인만 허용)
+        configuration.addAllowedMethod("*"); // 모든 HTTP 메소드 허용
         configuration.addAllowedHeader("*"); // 모든 헤더 허용
-        configuration.setAllowCredentials(true); // 쿠키 인증 허용
-
+        configuration.setAllowCredentials(true); // 인증정보 허용 (쿠키, 인증 헤더 등)
+        
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration);
+        source.registerCorsConfiguration("/**", configuration); // 모든 경로에 대해 적용
         return source;
     }
 
     @Bean
     public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder(); // 비밀번호 인코더 설정
+        return new BCryptPasswordEncoder(); // 비밀번호 암호화
     }
 }

--- a/src/main/java/com/fls/animecommunity/animesanctuary/controller/LoginController.java
+++ b/src/main/java/com/fls/animecommunity/animesanctuary/controller/LoginController.java
@@ -1,18 +1,45 @@
 package com.fls.animecommunity.animesanctuary.controller;
 
-import org.springframework.web.bind.annotation.GetMapping;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.fls.animecommunity.animesanctuary.dto.LoginRequest;
+import com.fls.animecommunity.animesanctuary.dto.LoginResponse;
+import com.fls.animecommunity.animesanctuary.service.impl.MemberService;
 
 @RestController
 public class LoginController {
 
-    @GetMapping("/login")
-    public String login() {
-        return "Login page";
-    }
+    private static final Logger log = LoggerFactory.getLogger(LoginController.class);
 
-    @GetMapping("/home")
-    public String home() {
-        return "Home page";
+    @Autowired
+    private MemberService memberService;
+
+    @PostMapping("/api/members/login")
+    public ResponseEntity<?> login(@RequestBody LoginRequest loginRequest) {
+        // 요청 로그
+        log.info("로그인 요청 도착: {}", loginRequest.getUsernameOrEmail());
+
+        // MemberService를 통해 로그인 검증
+        Long userId = memberService.validateLogin(loginRequest.getUsernameOrEmail(), loginRequest.getPassword());
+        
+        if (userId != null) {
+            // 로그인 성공 시
+            log.info("로그인 성공: userId={}", userId);
+            return ResponseEntity.ok(new LoginResponse("로그인 성공", userId));
+        } else {
+            // 로그인 실패 시
+            log.warn("로그인 실패: 아이디 또는 비밀번호가 잘못되었습니다.");
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(Map.of("message", "로그인 실패: 아이디 또는 비밀번호가 잘못되었습니다."));
+        }
     }
 }

--- a/src/main/java/com/fls/animecommunity/animesanctuary/controller/MemberController.java
+++ b/src/main/java/com/fls/animecommunity/animesanctuary/controller/MemberController.java
@@ -8,7 +8,6 @@ import java.util.UUID;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,7 +18,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.fls.animecommunity.animesanctuary.dto.LoginRequest;
 import com.fls.animecommunity.animesanctuary.dto.MemberRegisterDto;
 import com.fls.animecommunity.animesanctuary.model.UpdateProfileRequest;
 import com.fls.animecommunity.animesanctuary.model.member.GenderType;
@@ -27,7 +25,6 @@ import com.fls.animecommunity.animesanctuary.model.member.Member;
 import com.fls.animecommunity.animesanctuary.service.impl.MemberService;
 
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,25 +32,18 @@ import lombok.extern.slf4j.Slf4j;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/members")
-// @CrossOrigin(origins = { "http://localhost:9000/", "http://127.0.0.1:5501" })
 @Slf4j
 public class MemberController {
 
 	private final MemberService memberService;
 
 	@PostMapping("/register")
-	public ResponseEntity<?> register(@Valid @RequestBody MemberRegisterDto memberDto
-										, BindingResult result) {
-
-	    // 호출 확인 로그
+	public ResponseEntity<?> register(@Valid @RequestBody MemberRegisterDto memberDto, BindingResult result) {
 	    log.info("call MemberController register()");
 	    log.info("회원가입 요청 도착: /api/members/register");
-	    log.info("memberDto : {}",memberDto);
+	    log.info("memberDto : {}", memberDto);
 	    
-	    // 유효성 검사에서 에러가 있으면 에러 메시지를 반환
 	    if (result.hasErrors()) {
-	    	
-	    	log.info("result : {}",result);
 	        StringBuilder errorMessage = new StringBuilder();
 	        result.getFieldErrors().forEach(error -> {
 	            errorMessage.append(error.getField()).append(": ").append(error.getDefaultMessage()).append("; ");
@@ -61,14 +51,12 @@ public class MemberController {
 	        return ResponseEntity.badRequest().body(errorMessage.toString());
 	    }
 
-	    // Create a new Member object from the DTO
 	    Member member = new Member();
 	    member.setUsername(memberDto.getUsername());
 	    member.setPassword(memberDto.getPassword());  // 비밀번호는 해시 처리 필요
 	    member.setName(memberDto.getName());
 	    member.setEmail(memberDto.getEmail());
 
-	    // Gender 변환 중 유효하지 않은 값이 들어오면 예외 처리 , valueOf 예외발생가능성 있음.
 	    try {
 	        member.setGender(GenderType.valueOf(memberDto.getGender().toUpperCase()));
 	    } catch (IllegalArgumentException e) {
@@ -76,45 +64,13 @@ public class MemberController {
 	    }
 
 	    member.setBirth(memberDto.getBirth());
-	    
-	    log.info("member : {}",member);
-	    
-	    // 회원 등록 서비스 호출
 	    Member registeredMember = memberService.register(member);
-	    
-	    log.info("registeredMember : {}",registeredMember);
-	    
 	    return ResponseEntity.ok(registeredMember);
-	}
-
-
-	// login 로그인
-	@PostMapping("/login")
-	public ResponseEntity<?> login(@RequestBody LoginRequest loginRequest, HttpServletRequest request,
-									HttpServletResponse response) {
-		
-		Member member = memberService.login(loginRequest.getUsernameOrEmail(), loginRequest.getPassword());
-		
-		log.info("member : {} ", member);
-		
-		if (member != null) {
-			// 세션 생성
-			log.info("in if member : {} ", member);
-			request.getSession().setAttribute("user", member);
-			
-			// 성공 메시지 반환
-	        return ResponseEntity.ok("Login Success! Welcome, " + member.getUsername());
-		} else {
-			log.info("in else member : {} ", member);
-			return ResponseEntity.status(401).body("Invalid username/email or password");
-		}
 	}
 
 	// logout 로그아웃
 	@PostMapping("/logout")
 	public ResponseEntity<?> logout(HttpServletRequest request) {
-		
-		// 세션 무효화
 		request.getSession().invalidate();
 		return ResponseEntity.ok("Logout successful");
 	}
@@ -123,26 +79,19 @@ public class MemberController {
 	@DeleteMapping("/delete/{id}")
 	public ResponseEntity<Void> deleteMember(@PathVariable("id") Long id, @RequestParam("username") String username,
 											@RequestParam("password") String password, HttpServletRequest request) {
-		
-		// 로그인 여부 확인
 		Member loggedInMember = (Member) request.getSession().getAttribute("user");
-		
 		if (loggedInMember == null) {
 			return ResponseEntity.status(403).build(); // 로그인하지 않은 경우, Forbidden
 		}
 
-		// 로그인한 사용자만 삭제 가능
 		boolean isDeleted = memberService.deleteMember(id, password);
 		if (isDeleted) {
-			return ResponseEntity.ok().build(); // 회원 삭제 성공
+			return ResponseEntity.ok().build();
 		} else {
-			return ResponseEntity.status(401).build(); // 비밀번호가 일치하지 않음, Unauthorized
+			return ResponseEntity.status(401).build();
 		}
 	}
 
-	// update Profile = member의 모든 요소(username, password, )를 수정할수있게 함
-	// 바뀐 부분이 있으면 update되는 방식, 이 메서드하나로 해결이 가능하다.분리시킬필요없음
-	// 바꾸고 싶은것만 Body에 담아서 보내면 됨
 	@PostMapping("/updateProfile/{userId}")
 	public ResponseEntity<?> updateProfile(@PathVariable("userId") Long userId,
 			@RequestBody UpdateProfileRequest updateRequest) {
@@ -158,9 +107,6 @@ public class MemberController {
 		}
 	}
 
-	// Profile 프로필 관련
-
-	// getProfile 프로필 조회
 	@GetMapping("/profile/{id}")
 	public ResponseEntity<Member> getProfile(@PathVariable("id") Long id) {
 		Member member = memberService.getProfile(id);
@@ -171,33 +117,25 @@ public class MemberController {
 		}
 	}
 
-	// uploadProfileImage 프로필 이미지 업로드 하기
 	@PostMapping("/{userId}/uploadProfileImage")
 	public ResponseEntity<String> uploadProfileImage(@PathVariable("userId") Long userId,
 			@RequestParam("image") MultipartFile image) {
 		try {
-			// 저장할 파일 경로를 지정합니다 (경로 구분자를 명시적으로 사용하지 않음).
 			String uploadDir = Paths.get(System.getProperty("user.dir"), "uploads", "profile-images", userId.toString())
 					.toString();
-
-			// 파일 저장 경로를 확인하고 디렉토리가 존재하지 않으면 생성합니다.
 			File directory = new File(uploadDir);
 			if (!directory.exists() && !directory.mkdirs()) {
 				throw new IOException("Failed to create directory: " + uploadDir);
 			}
 
-			// 파일 이름을 설정합니다.
 			String originalFilename = image.getOriginalFilename();
 			String filePath = Paths.get(uploadDir, UUID.randomUUID().toString() + "_" + originalFilename).toString();
 
-			// 파일을 저장합니다.
 			File destinationFile = new File(filePath);
 			image.transferTo(destinationFile);
 
-			// 업로드된 파일의 경로를 데이터베이스에 저장합니다.
 			memberService.updateProfileImage(userId, filePath);
 
-			// 저장된 파일의 경로 또는 URL을 반환합니다.
 			return ResponseEntity.ok(filePath);
 		} catch (IOException | IllegalStateException e) {
 			return ResponseEntity.status(500).body("File I/O error: " + e.getMessage());
@@ -206,7 +144,6 @@ public class MemberController {
 		}
 	}
 
-	// deleteProfileImage 프로필 이미지 삭제
 	@DeleteMapping("/{userId}/deleteProfileImage")
 	public ResponseEntity<String> deleteProfileImage(@PathVariable("userId") Long userId) {
 		try {
@@ -219,14 +156,13 @@ public class MemberController {
 		}
 	}
 
-	// findByEmail 이메일로 사용자 찾기
 	@GetMapping("/findByEmail")
 	public ResponseEntity<Member> findByEmail(@RequestParam String email) {
 		Optional<Member> member = memberService.findByEmail(email);
 		if (member.isPresent()) {
 			return ResponseEntity.ok(member.get());
 		} else {
-			return ResponseEntity.status(404).build(); // Not Found
+			return ResponseEntity.status(404).build();
 		}
 	}
 }

--- a/src/main/java/com/fls/animecommunity/animesanctuary/dto/LoginResponse.java
+++ b/src/main/java/com/fls/animecommunity/animesanctuary/dto/LoginResponse.java
@@ -1,0 +1,29 @@
+package com.fls.animecommunity.animesanctuary.dto;
+
+public class LoginResponse {
+    private String message;
+    private Long userId;
+
+    // 생성자
+    public LoginResponse(String message, Long userId) {
+        this.message = message;
+        this.userId = userId;
+    }
+
+    // Getter와 Setter
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+}

--- a/src/main/java/com/fls/animecommunity/animesanctuary/repository/MemberRepository.java
+++ b/src/main/java/com/fls/animecommunity/animesanctuary/repository/MemberRepository.java
@@ -13,5 +13,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByUsername(String username);
     Optional<Member> findByEmail(String email);
     Optional<Member> findByUsernameOrEmail(String username, String email);
-	boolean existsByEmail(String email);
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/fls/animecommunity/animesanctuary/service/impl/MemberService.java
+++ b/src/main/java/com/fls/animecommunity/animesanctuary/service/impl/MemberService.java
@@ -58,8 +58,17 @@ public class MemberService {
     //login
     public Member login(String usernameOrEmail, String password) {
         Optional<Member> member = memberRepository.findByUsernameOrEmail(usernameOrEmail, usernameOrEmail);
+        return member.filter(m -> passwordEncoder.matches(password, m.getPassword())).orElse(null);
+    }
+    
+
+    // 로그인 검증 메서드
+    public Long validateLogin(String usernameOrEmail, String password) {
+        Optional<Member> member = memberRepository.findByUsernameOrEmail(usernameOrEmail, usernameOrEmail);
+        
         return member.filter(m -> passwordEncoder.matches(password, m.getPassword()))
-                     .orElse(null);
+                    .map(Member::getId)
+                    .orElse(null); // 로그인 실패 시 null 반환
     }
 
     @Transactional

--- a/src/test/java/com/fls/animecommunity/animesanctuary/service/MemberServiceTest.java
+++ b/src/test/java/com/fls/animecommunity/animesanctuary/service/MemberServiceTest.java
@@ -1,11 +1,10 @@
 package com.fls.animecommunity.animesanctuary.service;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-
-import java.util.Optional;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import static org.mockito.ArgumentMatchers.any;
@@ -17,6 +16,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import org.mockito.MockitoAnnotations;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
 import com.fls.animecommunity.animesanctuary.model.member.Member;
 import com.fls.animecommunity.animesanctuary.repository.MemberRepository;
 import com.fls.animecommunity.animesanctuary.service.impl.MemberService;
@@ -59,6 +59,7 @@ class MemberServiceTest {
         member.setUsername("testUser");
         member.setPassword("encodedPassword");
 
+        // findByUsernameOrEmail 메서드는 이제 하나의 인자만 받음
         when(memberRepository.findByUsernameOrEmail(anyString(), anyString())).thenReturn(Optional.of(member));
         when(passwordEncoder.matches(anyString(), anyString())).thenReturn(true);
 
@@ -69,6 +70,7 @@ class MemberServiceTest {
     
     @Test
     void login_shouldReturnNull_whenInvalidCredentialsAreGiven() {
+        // findByUsernameOrEmail 메서드는 이제 하나의 인자만 받음
         when(memberRepository.findByUsernameOrEmail(anyString(), anyString())).thenReturn(Optional.empty());
         when(passwordEncoder.matches(anyString(), anyString())).thenReturn(false);
 


### PR DESCRIPTION
- Moved login logic from MemberController to a dedicated LoginController.
- Removed login endpoint from MemberController to avoid ambiguity and focus responsibilities.
- LoginController now handles all login-related operations, ensuring clearer structure and better maintainability.
- Updated MemberController to focus on member registration, profile updates, and other non-login-related operations.